### PR TITLE
Volume requires brick

### DIFF
--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -66,7 +66,7 @@ define gluster::volume(
 	# available, which per node will happen right before this runs.
 	exec { "/usr/sbin/gluster volume create ${name} ${valid_replica}${valid_stripe}transport ${valid_transport} ${brick_spec}":
 		logoutput => on_failure,
-		unless => "/usr/sbin/gluster volume info | /bin/grep -qxF '${name}' -",	# add volume if it doesn't exist
+		unless => "/usr/sbin/gluster volume info | /bin/grep -qxF 'Volume Name: ${name}' -",	# add volume if it doesn't exist
 		#before => TODO?,
 		#require => Gluster::Brick[$bricks],
 		alias => "gluster-volume-create-${name}",


### PR DESCRIPTION
Hi,

When I attempted to use your puppet module, everything worked fine in my test environment. However, when I pushed to production, puppet was trying to load the volume resource before the brick, causing it to fail. I noticed you actually had a chained dependency in your code (but it was commented out). This pull request is to uncomment that line, which fixes my problem.

I looked at the blame and history log of your volume manifest to try and understand why you commented it, but could find no reason. It looks like it was commented out the minute it was added to git. Can you perhaps weigh in on why this line was commented out?

Thanks!
Daniel
