### PR TITLE
Builder Makefile: libselinux-python and starting sshd once

### DIFF
--- a/builder/Makefile
+++ b/builder/Makefile
@@ -67,6 +67,7 @@ $(OUTPUT)/builder.img: files/*
 	--size $(SIZE)G \
 	--install rsync,nfs-utils,sudo,openssh-server,openssh-clients \
 	--install screen,vim-enhanced,git,wget,file,man,tree,nmap,tcpdump,htop,lsof,telnet,mlocate,bind-utils,koan,iftop,yum-utils,nc \
+	--install libselinux-python \
 	--root-password file:files/password \
 	--upload files/epel-release-6-8.noarch.rpm:/root/epel-release-6-8.noarch.rpm \
 	--upload files/puppetlabs-release-el-6.noarch.rpm:/root/puppetlabs-release-el-6.noarch.rpm \

--- a/builder/Makefile
+++ b/builder/Makefile
@@ -27,9 +27,9 @@
 VERSION = centos-6
 BOX = $(VERSION).box
 SIZE = 40
-#OUTPUT = /tmp/gluster
+OUTPUT = /tmp/vagrant
 #OUTPUT := $(shell pwd)
-OUTPUT := $(shell echo ~/tmp/builder/gluster)
+#OUTPUT := $(shell echo ~/tmp/builder/gluster)
 SERVER = 'download.gluster.org'
 REMOTE_PATH = 'purpleidea/vagrant'
 

--- a/builder/Makefile
+++ b/builder/Makefile
@@ -76,6 +76,7 @@ $(OUTPUT)/builder.img: files/*
 	--run-command 'yum install -y /root/puppetlabs-release-el-6.noarch.rpm && rm -f /root/puppetlabs-release-el-6.noarch.rpm' \
 	--run-command 'yum install -y puppet' \
 	--run-command 'yum update -y' \
+	--run-command 'service sshd start' \
 	--run files/user.sh \
 	--run files/ssh.sh \
 	--run files/network.sh \

--- a/builder/Makefile
+++ b/builder/Makefile
@@ -30,8 +30,6 @@ SIZE = 40
 OUTPUT = /tmp/vagrant
 #OUTPUT := $(shell pwd)
 #OUTPUT := $(shell echo ~/tmp/builder/gluster)
-SERVER = 'download.gluster.org'
-REMOTE_PATH = 'purpleidea/vagrant'
 
 all: box
 
@@ -129,22 +127,4 @@ $(OUTPUT)/SHA256SUMS.asc: $(OUTPUT)/SHA256SUMS
 	@echo Running gpg...
 	# the --yes forces an overwrite of the SHA256SUMS.asc if necessary
 	gpg2 --yes --clearsign $(OUTPUT)/SHA256SUMS
-
-#
-#	upload
-#
-# upload to public server
-# NOTE: user downloads while file uploads are in progress don't cause problems!
-upload: $(OUTPUT)/$(BOX) $(OUTPUT)/SHA256SUMS $(OUTPUT)/SHA256SUMS.asc
-	if [ "`cat $(OUTPUT)/SHA256SUMS`" != "`ssh $(SERVER) 'cd $(REMOTE_PATH)/ && sha256sum $(BOX)'`" ]; then \
-		echo Running upload...; \
-		scp -p $(OUTPUT)/{$(BOX),SHA256SUMS{,.asc}} $(SERVER):$(REMOTE_PATH)/; \
-	fi
-# this method works too, but always hits the server on every make call
-#upload:
-#ifeq ($(shell cat $(OUTPUT)/SHA256SUMS), $(shell ssh $(SERVER) 'cd $(REMOTE_PATH)/ && sha256sum $(BOX)'))
-#	@echo true
-#else
-#	@echo false
-#endif
 


### PR DESCRIPTION
I added the package libselinux-python so that Ansible works properly (copying files is not possible otherwise).

Also, to avoid having different ssh fingerprints each time a machine is destroyed and rebooted I added a flag to start openssh once after installation.