### PR TITLE
Sort the bricks in the brick_spec

### DIFF
--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -181,7 +181,7 @@ define gluster::volume(
 	#}
 
 	# add /${name} to the end of each: brick:/path entry
-	$brick_spec = inline_template("<%= @valid_bricks.collect {|x| ''+x.chomp('/')+'/${name}' }.join(' ') %>")
+	$brick_spec = inline_template("<%= @valid_bricks.sort.collect {|x| ''+x.chomp('/')+'/${name}' }.join(' ') %>")
 
 	# if volume creation fails for a stupid reason, in many cases, glusterd
 	# already did some of the work and left us with volume name directories


### PR DESCRIPTION
When my gluster was misbehaving, I noticed the `create-${name}.sh` file getting regenerated each time I ran puppet, putting the bricks in different orders.
Let's sort the list for consistency, and to avoid unnecessary operations.
