### PR TITLE
Update mount.pp to play nice with Puppet 2.7.25

### DIFF
--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -39,7 +39,7 @@ define gluster::mount(
 	}
 	# because multiple gluster::mount types are allowed on the same server,
 	# we include with the ensure_resource function to avoid identical calls
-	ensure_resource('class', '::gluster::mount::base', $params)
+	ensure_resource('class', 'gluster::mount::base', $params)
 
 	# eg: vip:/volume
 	$split = split($server, ':')	# do some $server parsing


### PR DESCRIPTION
Before this patch:

```
Invalid tag "::gluster::mount::base" at /path/to/mount.pp:42
```
