### PR TITLE
Discover cut command location.

### DIFF
--- a/lib/facter/gluster_version.rb
+++ b/lib/facter/gluster_version.rb
@@ -25,13 +25,14 @@ if gluster == ''
 		gluster = '/usr/sbin/gluster'
 	end
 end
+cut = `which cut 2> /dev/null`.chomp
 
 # create the fact if the gluster executable exists
 if File.exist?(gluster)
 	Facter.add('gluster_version') do
 		#confine :operatingsystem => %w{CentOS, RedHat, Fedora}
 		setcode {
-			Facter::Util::Resolution.exec(gluster+' --version | /usr/bin/head -1 | /bin/cut -d " " -f 2').chomp
+			Facter::Util::Resolution.exec(gluster+' --version | /usr/bin/head -1 | '+cut+' -d " " -f 2').chomp
 		}
 	end
 end


### PR DESCRIPTION
This fix issues with Debian Squeeze and later that include newer coreutils
package which puts `cut` in `/usr/bin`.
