### PR TITLE
Fix Debian compatibility

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -126,7 +126,7 @@ define gluster::repo(
 
 			apt::source { "${name}":
 				location => "${base_os}wheezy/apt",
-				release => 'wheezy',
+				release => "${operatingsystemrelease},
 				repos => 'main',
 				key => '21C74DF2',
 				key_source => "${base_os}wheezy/pubkey.gpg",

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -9,7 +9,7 @@
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 #
 # You should have received a copy of the GNU Affero General Public License

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -9,7 +9,7 @@
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
 # GNU Affero General Public License for more details.
 #
 # You should have received a copy of the GNU Affero General Public License
@@ -81,6 +81,7 @@ define gluster::repo(
 	}
 
 	$arch = "${architecture}" ? {
+		'amd64' => 'binary-amd64',
 		'x86_64' => 'x86_64',
 		'i386' => 'i386',
 		'i486' => 'i386',
@@ -120,15 +121,15 @@ define gluster::repo(
 			#	ensure => present,
 			#}
 		}
-		case 'Debian': {
+		'Debian': {
 			include ::apt
 
 			apt::source { "${name}":
-				location	=> "${base_os}apt",
-				release		=> 'wheezy',
-				repos		=> 'main',
-				key		=> '21C74DF2',
-				key_source	=> "${base_os}pubkey.gpg",
+				location => "${base_os}wheezy/apt",
+				release => 'wheezy',
+				repos => 'main',
+				key => '21C74DF2',
+				key_source => "${base_os}wheezy/pubkey.gpg",
 			}
 		}
 	}

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -54,7 +54,7 @@ class gluster::server(
 	file { "${vardir}/sponge.py":		# for scripts needing: 'sponge'
 		source => 'puppet:///modules/gluster/sponge.py',
 		owner => root,
-		group => nobody,
+		group => root,
 		mode => 700,			# u=rwx
 		backup => false,		# don't backup to filebucket
 		ensure => present,

--- a/manifests/vardir.pp
+++ b/manifests/vardir.pp
@@ -29,7 +29,7 @@ class gluster::vardir {	# module vardir snippet
 			purge => true,		# purge all unmanaged files
 			force => true,		# also purge subdirs and links
 			owner => root,
-			group => nobody,
+			group => root,
 			mode => 600,
 			backup => false,	# don't backup to filebucket
 			#before => File["${module_vardir}"],	# redundant
@@ -44,7 +44,7 @@ class gluster::vardir {	# module vardir snippet
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => root, group => root, mode => 600, backup => false,
 		require => File["${tmp}"],	# File['/var/lib/puppet/tmp/']
 	}
 }

--- a/manifests/volume/property/group/data.pp
+++ b/manifests/volume/property/group/data.pp
@@ -33,7 +33,7 @@ class gluster::volume::property::group::data() {
 		purge => true,
 		force => true,
 		owner => root,
-		group => nobody,
+		group => root,
 		mode => 644,			# u=rwx
 		backup => false,		# don't backup to filebucket
 		require => File["${vardir}/"],

--- a/manifests/xml.pp
+++ b/manifests/xml.pp
@@ -39,7 +39,7 @@ class gluster::xml {
 	file { "${vardir}/xml.py":
 		source => 'puppet:///modules/gluster/xml.py',
 		owner => root,
-		group => nobody,
+		group => root,
 		mode => 700,			# u=rwx
 		backup => false,		# don't backup to filebucket
 		ensure => present,


### PR DESCRIPTION
APT uses "amd64" instead of "x86_64" as the architecture label. Debian doesn't come with a `nobody` group, but uses `nogroup` instead. However, since the owner is `root`, I used the `root` group as well.

Gluster's repo is a little weird in that "wheezy" is hard-coded in the URL.