### PR TITLE
Add Gluster 3.6.1 compatibility for CentOS 6.6

### DIFF
--- a/data/params/RedHat/CentOS/6.6.yaml
+++ b/data/params/RedHat/CentOS/6.6.yaml
@@ -1,4 +1,10 @@
-# gluster/data/params/RedHat/CentOS/6.5.yaml
+# gluster/data/params/RedHat/CentOS/6.6.yaml
 ---
-gluster::params::seluser: 'unconfined_u'	# standard of system_u causes puppet to restart gluster on each run due to modifications.
+# looks like this may be irrelevant after all as  CentOS 6.6 
+# appears to accept system_u; however, it required a reboot for 
+# puppet to stop looping through modifying files on each iteration.
+gluster::params::selinux_glusterd_seluser: 'system_u'	
+
+
+
 # vim: ts=8

--- a/data/params/RedHat/CentOS/6.6.yaml
+++ b/data/params/RedHat/CentOS/6.6.yaml
@@ -1,0 +1,4 @@
+# gluster/data/params/RedHat/CentOS/6.5.yaml
+---
+gluster::params::seluser: 'unconfined_u'	# standard of system_u causes puppet to restart gluster on each run due to modifications.
+# vim: ts=8

--- a/data/versions/3.6.1.yaml
+++ b/data/versions/3.6.1.yaml
@@ -1,0 +1,4 @@
+# gluster/data/versions/3.6.1.yaml
+---
+gluster::versions::operating_version: '30600'   # v3.6.1
+# vim: ts=8

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -114,7 +114,7 @@ define gluster::host(
 				group => root,
 				mode => 600,			# u=rw,go=r
 				seltype => 'glusterd_var_lib_t',
-				seluser => "${::gluster::params::seluser}",
+				seluser => "${::gluster::params::selinux_glusterd_seluser}",
 				ensure => present,
 				notify => Service["${::gluster::params::service_glusterd}"],
 				require => File['/var/lib/glusterd/'],
@@ -200,7 +200,7 @@ define gluster::host(
 				# NOTE: this mode was found by inspecting the process
 				mode => 600,			# u=rw,go=r
 				seltype => 'glusterd_var_lib_t',
-				seluser => "${::gluster::params::seluser}",
+				seluser => "${::gluster::params::selinux_glusterd_seluser}",
 				notify => [
 					# propagate the notify up
 					File['/var/lib/glusterd/peers/'],

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -114,7 +114,7 @@ define gluster::host(
 				group => root,
 				mode => 600,			# u=rw,go=r
 				seltype => 'glusterd_var_lib_t',
-				seluser => 'system_u',
+				seluser => "${::gluster::params::seluser}",
 				ensure => present,
 				notify => Service["${::gluster::params::service_glusterd}"],
 				require => File['/var/lib/glusterd/'],
@@ -200,7 +200,7 @@ define gluster::host(
 				# NOTE: this mode was found by inspecting the process
 				mode => 600,			# u=rw,go=r
 				seltype => 'glusterd_var_lib_t',
-				seluser => 'system_u',
+				seluser => "${::gluster::params::seluser}",
 				notify => [
 					# propagate the notify up
 					File['/var/lib/glusterd/peers/'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -54,7 +54,7 @@ class gluster::params(
 	$program_findmnt = '/bin/findmnt',
 
 	# SELinux
-	$seluser = 'system_u',
+	$selinux_glusterd_seluser = 'system_u',
 
 	# services...
 	$service_glusterd = 'glusterd',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,6 +53,9 @@ class gluster::params(
 	$program_fping = '/usr/sbin/fping',
 	$program_findmnt = '/bin/findmnt',
 
+	# SELinux
+	$seluser = 'system_u',
+
 	# services...
 	$service_glusterd = 'glusterd',
 


### PR DESCRIPTION
#help resolve repeated modification to

--- /var/lib/glusterd/glusterd.info
@@ -1,2 +1 @@
 UUID=abc.def.xyz
-operating-version=1