### PR TITLE
Updated module in order to work on Ubuntu 14.04

### DIFF
--- a/data/params/Debian.yaml
+++ b/data/params/Debian.yaml
@@ -4,6 +4,12 @@ gluster::params::package_glusterfs: 'glusterfs-client'
 gluster::params::package_glusterfs_api: ''      # doesn't exist
 gluster::params::package_glusterfs_fuse: ''     # doesn't exist
 gluster::params::service_glusterd: 'glusterfs-server'
+gluster::params::data_owner: 'root'
+gluster::params::data_group: 'nogroup'
+gluster::params::conf_owner: 'root'
+gluster::params::conf_group: 'root'
+gluster::params::program_fping: '/usr/bin/fping'
+gluster::params::program_awk: '/usr/bin/awk'
 # TODO: the debian family of glusterd needs a reload command in the init file !
 gluster::params::misc_gluster_reload: '/usr/sbin/service glusterfs-server restart'
 # vim: ts=8

--- a/data/params/Debian.yaml
+++ b/data/params/Debian.yaml
@@ -4,10 +4,10 @@ gluster::params::package_glusterfs: 'glusterfs-client'
 gluster::params::package_glusterfs_api: ''      # doesn't exist
 gluster::params::package_glusterfs_fuse: ''     # doesn't exist
 gluster::params::service_glusterd: 'glusterfs-server'
-gluster::params::data_owner: 'root'
-gluster::params::data_group: 'nogroup'
-gluster::params::conf_owner: 'root'
-gluster::params::conf_group: 'root'
+gluster::params::misc_owner_data: 'root'
+gluster::params::misc_group_data: 'nogroup'
+gluster::params::misc_owner_conf: 'root'
+gluster::params::misc_group_conf: 'root'
 gluster::params::program_fping: '/usr/bin/fping'
 gluster::params::program_awk: '/usr/bin/awk'
 # TODO: the debian family of glusterd needs a reload command in the init file !

--- a/lib/puppet/parser/functions/brick_layout_simple.rb
+++ b/lib/puppet/parser/functions/brick_layout_simple.rb
@@ -51,10 +51,6 @@ module Puppet::Parser::Functions
 		replica = args[0].to_i	# convert from string if needed
 		bricks = args[1]
 
-		# TODO: these functions could be in separate puppet files
-		# eg: Puppet::Parser::Functions.function('myfunc')
-		# function_myfunc(...)
-
 		collect = {}
 		parsed = function_brick_str_to_hash([bricks])
 		parsed.each do |x|

--- a/manifests/brick.pp
+++ b/manifests/brick.pp
@@ -446,7 +446,7 @@ define gluster::brick(
 				logoutput => on_failure,
 				unless => [		# if one element is true, this *doesn't* run
 					#"${::gluster::params::program_lvdisplay} ${lvm_lvname}",	# nope!
-					"${::gluster::params::program_lvs} --separator ':' | /usr/bin/tr -d ' ' | /bin/awk -F ':' '{print \$1}' | /bin/grep -q '${lvm_lvname}'",
+					"${::gluster::params::program_lvs} --separator ':' | /usr/bin/tr -d ' ' | ${::gluster::params::program_awk} -F ':' '{print \$1}' | /bin/grep -q '${lvm_lvname}'",
 					'/bin/false',	# TODO: add more criteria
 				],
 				require => $exec_requires,

--- a/manifests/brick.pp
+++ b/manifests/brick.pp
@@ -74,8 +74,8 @@ define gluster::brick(
 	$safename = regsubst("${name}", '/', '_', 'G')	# make /'s safe
 	file { "${vardir}/brick/${safename}.${group}":
 		content => "${name}\n",
-		owner => $::gluster::params::conf_owner,
-		group => $::gluster::params::conf_group,
+		owner => "${::gluster::params::misc_owner_conf}",
+		group => "${::gluster::params::misc_group_conf}",
 		mode => 644,
 		ensure => present,
 		require => File["${vardir}/brick/"],
@@ -96,8 +96,8 @@ define gluster::brick(
 		# $group is unnecessary, but i left it in for consistency...
 		file { "${vardir}/brick/fsuuid/${safename}.${group}":
 			content => "${fsuuid}\n",
-			owner => $::gluster::params::conf_owner,
-			group => $::gluster::params::conf_group,
+			owner => "${::gluster::params::misc_owner_conf}",
+			group => "${::gluster::params::misc_group_conf}",
 			mode => 600,	# might as well...
 			ensure => present,
 			require => File["${vardir}/brick/fsuuid/"],

--- a/manifests/brick.pp
+++ b/manifests/brick.pp
@@ -74,8 +74,8 @@ define gluster::brick(
 	$safename = regsubst("${name}", '/', '_', 'G')	# make /'s safe
 	file { "${vardir}/brick/${safename}.${group}":
 		content => "${name}\n",
-		owner => root,
-		group => root,
+		owner => $::gluster::params::conf_owner,
+		group => $::gluster::params::conf_group,
 		mode => 644,
 		ensure => present,
 		require => File["${vardir}/brick/"],
@@ -96,8 +96,8 @@ define gluster::brick(
 		# $group is unnecessary, but i left it in for consistency...
 		file { "${vardir}/brick/fsuuid/${safename}.${group}":
 			content => "${fsuuid}\n",
-			owner => root,
-			group => root,
+			owner => $::gluster::params::conf_owner,
+			group => $::gluster::params::conf_group,
 			mode => 600,	# might as well...
 			ensure => present,
 			require => File["${vardir}/brick/fsuuid/"],

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -75,8 +75,8 @@ define gluster::host(
 				'' => undef,
 				default => "${uuid}\n",
 			},
-			owner => root,
-			group => root,
+			owner => $::gluster::params::conf_owner,
+			group => $::gluster::params::conf_group,
 			mode => 600,	# might as well...
 			ensure => present,
 			require => File["${vardir}/uuid/"],
@@ -110,8 +110,8 @@ define gluster::host(
 			# set a unique uuid per host, and operating version...
 			file { '/var/lib/glusterd/glusterd.info':
 				content => template('gluster/glusterd.info.erb'),
-				owner => root,
-				group => root,
+				owner => $::gluster::params::conf_owner,
+				group => $::gluster::params::conf_group,
 				mode => 600,			# u=rw,go=r
 				seltype => 'glusterd_var_lib_t',
 				seluser => 'system_u',
@@ -124,8 +124,8 @@ define gluster::host(
 			@@file { "${vardir}/uuid/uuid_${name}":
 				content => "${valid_uuid}\n",
 				tag => 'gluster_uuid',
-				owner => root,
-				group => root,
+				owner => $::gluster::params::conf_owner,
+				group => $::gluster::params::conf_group,
 				mode => 600,
 				ensure => present,
 			}
@@ -195,8 +195,8 @@ define gluster::host(
 			# tag the file so it doesn't get removed by purge
 			file { "/var/lib/glusterd/peers/${valid_uuid}":
 				ensure => present,
-				owner => root,
-				group => root,
+				owner => $::gluster::params::conf_owner,
+				group => $::gluster::params::conf_group,
 				# NOTE: this mode was found by inspecting the process
 				mode => 600,			# u=rw,go=r
 				seltype => 'glusterd_var_lib_t',
@@ -230,8 +230,8 @@ define gluster::host(
 		# store so that a fact can figure out the interface and cidr...
 		file { "${vardir}/vrrp/ip":
 			content => "${valid_ip}\n",
-			owner => root,
-			group => root,
+			owner => $::gluster::params::conf_owner,
+			group => $::gluster::params::conf_group,
 			mode => 600,	# might as well...
 			ensure => present,
 			require => File["${vardir}/vrrp/"],
@@ -243,8 +243,8 @@ define gluster::host(
 				'' => undef,
 				default => "${password}",
 			},
-			owner => root,
-			group => root,
+			owner => $::gluster::params::conf_owner,
+			group => $::gluster::params::conf_group,
 			mode => 600,	# might as well...
 			ensure => present,
 			require => File["${vardir}/vrrp/"],
@@ -254,8 +254,8 @@ define gluster::host(
 		@@file { "${vardir}/vrrp/vrrp_${name}":
 			content => "${::gluster_vrrp}\n",
 			tag => 'gluster_vrrp',
-			owner => root,
-			group => root,
+			owner => $::gluster::params::conf_owner,
+			group => $::gluster::params::conf_group,
 			mode => 600,
 			ensure => present,
 		}

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -75,8 +75,8 @@ define gluster::host(
 				'' => undef,
 				default => "${uuid}\n",
 			},
-			owner => $::gluster::params::conf_owner,
-			group => $::gluster::params::conf_group,
+			owner => "${::gluster::params::misc_owner_conf}",
+			group => "${::gluster::params::misc_group_conf}",
 			mode => 600,	# might as well...
 			ensure => present,
 			require => File["${vardir}/uuid/"],
@@ -110,8 +110,8 @@ define gluster::host(
 			# set a unique uuid per host, and operating version...
 			file { '/var/lib/glusterd/glusterd.info':
 				content => template('gluster/glusterd.info.erb'),
-				owner => $::gluster::params::conf_owner,
-				group => $::gluster::params::conf_group,
+				owner => "${::gluster::params::misc_owner_conf}",
+				group => "${::gluster::params::misc_group_conf}",
 				mode => 600,			# u=rw,go=r
 				seltype => 'glusterd_var_lib_t',
 				seluser => 'system_u',
@@ -124,8 +124,8 @@ define gluster::host(
 			@@file { "${vardir}/uuid/uuid_${name}":
 				content => "${valid_uuid}\n",
 				tag => 'gluster_uuid',
-				owner => $::gluster::params::conf_owner,
-				group => $::gluster::params::conf_group,
+				owner => "${::gluster::params::misc_owner_conf}",
+				group => "${::gluster::params::misc_group_conf}",
 				mode => 600,
 				ensure => present,
 			}
@@ -195,8 +195,8 @@ define gluster::host(
 			# tag the file so it doesn't get removed by purge
 			file { "/var/lib/glusterd/peers/${valid_uuid}":
 				ensure => present,
-				owner => $::gluster::params::conf_owner,
-				group => $::gluster::params::conf_group,
+				owner => "${::gluster::params::misc_owner_conf}",
+				group => "${::gluster::params::misc_group_conf}",
 				# NOTE: this mode was found by inspecting the process
 				mode => 600,			# u=rw,go=r
 				seltype => 'glusterd_var_lib_t',
@@ -230,8 +230,8 @@ define gluster::host(
 		# store so that a fact can figure out the interface and cidr...
 		file { "${vardir}/vrrp/ip":
 			content => "${valid_ip}\n",
-			owner => $::gluster::params::conf_owner,
-			group => $::gluster::params::conf_group,
+			owner => "${::gluster::params::misc_owner_conf}",
+			group => "${::gluster::params::misc_group_conf}",
 			mode => 600,	# might as well...
 			ensure => present,
 			require => File["${vardir}/vrrp/"],
@@ -243,8 +243,8 @@ define gluster::host(
 				'' => undef,
 				default => "${password}",
 			},
-			owner => $::gluster::params::conf_owner,
-			group => $::gluster::params::conf_group,
+			owner => "${::gluster::params::misc_owner_conf}",
+			group => "${::gluster::params::misc_group_conf}",
 			mode => 600,	# might as well...
 			ensure => present,
 			require => File["${vardir}/vrrp/"],
@@ -254,8 +254,8 @@ define gluster::host(
 		@@file { "${vardir}/vrrp/vrrp_${name}":
 			content => "${::gluster_vrrp}\n",
 			tag => 'gluster_vrrp',
-			owner => $::gluster::params::conf_owner,
-			group => $::gluster::params::conf_group,
+			owner => "${::gluster::params::misc_owner_conf}",
+			group => "${::gluster::params::misc_group_conf}",
 			mode => 600,
 			ensure => present,
 		}

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -25,7 +25,7 @@ define gluster::mount(
 	$repo = true,		# add a repo automatically? true or false
 	$version = '',		# pick a specific version (defaults to latest)
 	$ip = '',		# you can specify which ip address to use (if multiple)
-	$type = 'glusterfs',	# use 'glusterfs' or 'ntfs'
+	$type = 'glusterfs',	# use 'glusterfs' or 'nfs'
 	$shorewall = false,
 ) {
 	include gluster::params
@@ -78,7 +78,7 @@ define gluster::mount(
 		fail('No valid IP exists!')
 	}
 
-	# TODO: review shorewall rules against ntfs fstype mount option
+	# TODO: review shorewall rules against nfs fstype mount option
 	if $shorewall {
 		$safename = regsubst("${name}", '/', '_', 'G')	# make /'s safe
 		@@shorewall::rule { "glusterd-management-${fqdn}-${safename}":
@@ -144,7 +144,7 @@ define gluster::mount(
 		alias => "${mount_short_name}",	# don't allow duplicates name's
 	}
 
-	# TODO: review packages content against ntfs fstype mount option
+	# TODO: review packages content against nfs fstype mount option
 	$packages = "${::gluster::params::package_glusterfs_fuse}" ? {
 		'' => ["${::gluster::params::package_glusterfs}"],
 		default => [
@@ -152,6 +152,12 @@ define gluster::mount(
 			"${::gluster::params::package_glusterfs_fuse}",
 		],
 	}
+
+	$valid_type = "${type}" ? {
+		'nfs' => 'nfs',
+		default => 'glusterfs',
+	}
+
 	# Mount Options:
 	# * backupvolfile-server=server-name
 	# * fetch-attempts=N (where N is number of attempts)
@@ -168,7 +174,7 @@ define gluster::mount(
 		atboot => true,
 		ensure => $mounted_bool,
 		device => "${server}",
-		fstype => "${type}",
+		fstype => "${valid_type}",
 		options => "defaults,_netdev,${rw_bool}",	# TODO: will $suid_bool work with gluster ?
 		dump => '0',		# fs_freq: 0 to skip file system dumps
 		pass => '0',		# fs_passno: 0 to skip fsck on boot

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -24,8 +24,9 @@ define gluster::mount(
 				# defs, but not actually mount (testing)
 	$repo = true,		# add a repo automatically? true or false
 	$version = '',		# pick a specific version (defaults to latest)
-	$ip = '',	# you can specify which ip address to use (if multiple)
-	$shorewall = false
+	$ip = '',		# you can specify which ip address to use (if multiple)
+	$type = 'glusterfs',	# use 'glusterfs' or 'ntfs'
+	$shorewall = false,
 ) {
 	include gluster::params
 
@@ -63,8 +64,8 @@ define gluster::mount(
 		fail('The $server must match a $host:/$volume pattern.')
 	}
 
-	$short_name = sprintf("%s", regsubst("${name}", '\/$', ''))	# no trailing
-	$long_name = sprintf("%s/", regsubst("${name}", '\/$', ''))	# trailing...
+	$mount_short_name = sprintf("%s", regsubst("${name}", '\/$', ''))	# no trailing
+	$mount_long_name = sprintf("%s/", regsubst("${name}", '\/$', ''))	# trailing...
 
 	$valid_ip = "${ip}" ? {
 		'' => "${::gluster_host_ip}" ? {	# smart fact...
@@ -77,6 +78,7 @@ define gluster::mount(
 		fail('No valid IP exists!')
 	}
 
+	# TODO: review shorewall rules against ntfs fstype mount option
 	if $shorewall {
 		$safename = regsubst("${name}", '/', '_', 'G')	# make /'s safe
 		@@shorewall::rule { "glusterd-management-${fqdn}-${safename}":
@@ -125,23 +127,24 @@ define gluster::mount(
 		default => mounted,
 	}
 
-	# ensure parent directories exist
+	# ensure parent directories exist for mount point
 	exec { "gluster-mount-mkdir-${name}":
-		command => "/bin/mkdir -p '${long_name}'",
-		creates => "${long_name}",
+		command => "/bin/mkdir -p '${mount_long_name}'",
+		creates => "${mount_long_name}",
 		logoutput => on_failure,
-		before => File["${long_name}"],
+		before => File["${mount_long_name}"],
 	}
 
 	# make an empty directory for the mount point
-	file { "${long_name}":			# ensure a trailing slash
+	file { "${mount_long_name}":		# ensure a trailing slash
 		ensure => directory,		# make sure this is a directory
 		recurse => false,		# don't recurse into directory
 		purge => false,			# don't purge unmanaged files
 		force => false,			# don't purge subdirs and links
-		alias => "${short_name}",	# don't allow duplicates name's
+		alias => "${mount_short_name}",	# don't allow duplicates name's
 	}
 
+	# TODO: review packages content against ntfs fstype mount option
 	$packages = "${::gluster::params::package_glusterfs_fuse}" ? {
 		'' => ["${::gluster::params::package_glusterfs}"],
 		default => [
@@ -161,18 +164,18 @@ define gluster::mount(
 	# * selinux (enable selinux on GlusterFS mount)
 	# XXX: consider mounting only if some exported resource, collected and turned into a fact shows that the volume is available...
 	# XXX: or something... consider adding the notify => Poke[] functionality
-	mount { "${short_name}":
+	mount { "${mount_short_name}":
 		atboot => true,
 		ensure => $mounted_bool,
 		device => "${server}",
-		fstype => 'glusterfs',
+		fstype => "${type}",
 		options => "defaults,_netdev,${rw_bool}",	# TODO: will $suid_bool work with gluster ?
 		dump => '0',		# fs_freq: 0 to skip file system dumps
 		pass => '0',		# fs_passno: 0 to skip fsck on boot
 		require => [
 			Package[$packages],
-			File["${long_name}"],		# the mountpoint
-			Exec['gluster-fuse'],	# ensure fuse is loaded!
+			File["${mount_long_name}"],	# the mountpoint
+			Exec['gluster-fuse'],		# ensure fuse is loaded!
 		],
 	}
 }

--- a/manifests/mount/base.pp
+++ b/manifests/mount/base.pp
@@ -24,6 +24,9 @@ class gluster::mount::base(
 	#$vardir = $::gluster::vardir::module_vardir	# with trailing slash
 	$vardir = regsubst($::gluster::vardir::module_vardir, '\/$', '')
 
+	$log_short_name = sprintf("%s", regsubst("${::gluster::params::gluster_log_directory}", '\/$', ''))	# no trailing
+	$log_long_name = sprintf("%s/", regsubst("${::gluster::params::gluster_log_directory}", '\/$', ''))	# trailing...
+
 	# if we use ::mount and ::server on the same machine, this could clash,
 	# so we use the ensure_resource function to allow identical duplicates!
 	$rname = "${version}" ? {
@@ -92,6 +95,24 @@ class gluster::mount::base(
 	#	mode => 644,		# u=rw,go=r
 	#	ensure => present,
 	#}
+
+	# ensure parent directories exist for log directory
+	exec { "gluster-log-mkdir-${name}":
+		command => "/bin/mkdir -p '${log_long_name}'",
+		creates => "${log_long_name}",
+		logoutput => on_failure,
+		before => File["${log_long_name}"],
+	}
+
+	# make an empty directory for logs
+	file { "${log_long_name}":          # ensure a trailing slash
+		ensure => directory,            # make sure this is a directory
+		recurse => false,               # don't recurse into directory
+		purge => false,                 # don't purge unmanaged files
+		force => false,                 # don't purge subdirs and links
+		alias => "${log_short_name}",   # don't allow duplicates name's
+	}
+
 }
 
 # vim: ts=8

--- a/manifests/mount/base.pp
+++ b/manifests/mount/base.pp
@@ -87,8 +87,8 @@ class gluster::mount::base(
 	# TODO: will this autoload the fuse module?
 	#file { '/etc/modprobe.d/fuse.conf':
 	#	content => "fuse\n",	# TODO: "install fuse ${::gluster::params::program_modprobe} --ignore-install fuse ; /bin/true\n" ?
-	#	owner => root,
-	#	group => root,
+	#	owner => $::gluster::params::conf_owner,
+	#	group => $::gluster::params::conf_group,
 	#	mode => 644,		# u=rw,go=r
 	#	ensure => present,
 	#}

--- a/manifests/mount/base.pp
+++ b/manifests/mount/base.pp
@@ -90,8 +90,8 @@ class gluster::mount::base(
 	# TODO: will this autoload the fuse module?
 	#file { '/etc/modprobe.d/fuse.conf':
 	#	content => "fuse\n",	# TODO: "install fuse ${::gluster::params::program_modprobe} --ignore-install fuse ; /bin/true\n" ?
-	#	owner => $::gluster::params::conf_owner,
-	#	group => $::gluster::params::conf_group,
+	#	owner => "${::gluster::params::misc_owner_conf}",
+	#	group => "${::gluster::params::misc_group_conf}",
 	#	mode => 644,		# u=rw,go=r
 	#	ensure => present,
 	#}

--- a/manifests/mount/base.pp
+++ b/manifests/mount/base.pp
@@ -24,8 +24,8 @@ class gluster::mount::base(
 	#$vardir = $::gluster::vardir::module_vardir	# with trailing slash
 	$vardir = regsubst($::gluster::vardir::module_vardir, '\/$', '')
 
-	$log_short_name = sprintf("%s", regsubst("${::gluster::params::gluster_log_directory}", '\/$', ''))	# no trailing
-	$log_long_name = sprintf("%s/", regsubst("${::gluster::params::gluster_log_directory}", '\/$', ''))	# trailing...
+	$log_short_name = sprintf("%s", regsubst("${::gluster::params::misc_gluster_logs}", '\/$', ''))	# no trailing
+	$log_long_name = sprintf("%s/", regsubst("${::gluster::params::misc_gluster_logs}", '\/$', ''))	# trailing...
 
 	# if we use ::mount and ::server on the same machine, this could clash,
 	# so we use the ensure_resource function to allow identical duplicates!

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,10 +55,10 @@ class gluster::params(
 	$program_awk = '/bin/awk',
 
 	# Owner/Group
-	$data_owner = 'root',
-	$data_group = 'nobody',
-	$conf_owner = 'root',
-	$conf_group = 'root',
+	$misc_owner_data = 'root',
+	$misc_group_data = 'nobody',
+	$misc_owner_conf = 'root',
+	$misc_group_conf = 'root',
 
 	# services...
 	$service_glusterd = 'glusterd',
@@ -102,8 +102,8 @@ class gluster::params(
 		# create a custom external fact!
 		file { "${factbase}gluster_program.yaml":
 			content => inline_template('<%= @hash.to_yaml %>'),
-			owner => $conf_owner,
-			group => $conf_group,
+			owner => "${misc_owner_conf}",
+			group => "${misc_group_conf}",
 			mode => 644,		# u=rw,go=r
 			ensure => present,
 		}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -52,6 +52,7 @@ class gluster::params(
 
 	$program_fping = '/usr/sbin/fping',
 	$program_findmnt = '/bin/findmnt',
+	$program_awk = '/bin/awk',
 
 	# Owner/Group
 	$data_owner = 'root',
@@ -64,6 +65,10 @@ class gluster::params(
 
 	# external modules...
 	$include_puppet_facter = true,
+
+	# Default directories
+	# See http://manpages.ubuntu.com/manpages/trusty/man8/mount.glusterfs.8.html
+	$gluster_log_directory = '/var/log/glusterfs/',
 
 	# misc...
 	$misc_gluster_reload = '/sbin/service glusterd reload',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,6 +53,12 @@ class gluster::params(
 	$program_fping = '/usr/sbin/fping',
 	$program_findmnt = '/bin/findmnt',
 
+	# Owner/Group
+	$data_owner = 'root',
+	$data_group = 'nobody',
+	$conf_owner = 'root',
+	$conf_group = 'root',
+
 	# services...
 	$service_glusterd = 'glusterd',
 
@@ -91,8 +97,8 @@ class gluster::params(
 		# create a custom external fact!
 		file { "${factbase}gluster_program.yaml":
 			content => inline_template('<%= @hash.to_yaml %>'),
-			owner => root,
-			group => root,
+			owner => $conf_owner,
+			group => $conf_group,
 			mode => 644,		# u=rw,go=r
 			ensure => present,
 		}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -68,7 +68,7 @@ class gluster::params(
 
 	# Default directories
 	# See http://manpages.ubuntu.com/manpages/trusty/man8/mount.glusterfs.8.html
-	$gluster_log_directory = '/var/log/glusterfs/',
+	$misc_gluster_logs = '/var/log/glusterfs/',
 
 	# misc...
 	$misc_gluster_reload = '/sbin/service glusterd reload',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -53,8 +53,8 @@ class gluster::server(
 	# this is meant to be replace the excellent sponge utility by sponge.py
 	file { "${vardir}/sponge.py":		# for scripts needing: 'sponge'
 		source => 'puppet:///modules/gluster/sponge.py',
-		owner => $::gluster::params::data_owner,
-		group => $::gluster::params::data_group,
+		owner => "${::gluster::params::misc_owner_data}",
+		group => "${::gluster::params::misc_group_data}",
 		mode => 700,			# u=rwx
 		backup => false,		# don't backup to filebucket
 		ensure => present,
@@ -89,8 +89,8 @@ class gluster::server(
 		recurse => false,		# TODO: eventually...
 		purge => false,			# TODO: eventually...
 		force => false,			# TODO: eventually...
-		owner => $::gluster::params::conf_owner,
-		group => $::gluster::params::conf_group,
+		owner => "${::gluster::params::misc_owner_conf}",
+		group => "${::gluster::params::misc_group_conf}",
 		mode => 644,
 		#notify => Service["${::gluster::params::service_glusterd}"],	# TODO: ???
 		require => Package["${::gluster::params::package_glusterfs_server}"],
@@ -107,8 +107,8 @@ class gluster::server(
 
 	file { '/etc/glusterfs/glusterd.vol':
 		content => template('gluster/glusterd.vol.erb'),
-		owner => $::gluster::params::conf_owner,
-		group => $::gluster::params::conf_group,
+		owner => "${::gluster::params::misc_owner_conf}",
+		group => "${::gluster::params::misc_group_conf}",
 		mode => 644,			# u=rw,go=r
 		ensure => present,
 		require => File['/etc/glusterfs/'],
@@ -119,8 +119,8 @@ class gluster::server(
 		recurse => false,		# TODO: eventually...
 		purge => false,			# TODO: eventually...
 		force => false,			# TODO: eventually...
-		owner => $::gluster::params::conf_owner,
-		group => $::gluster::params::conf_group,
+		owner => "${::gluster::params::misc_owner_conf}",
+		group => "${::gluster::params::misc_group_conf}",
 		mode => 644,
 		#notify => Service["${::gluster::params::service_glusterd}"],	# TODO: eventually...
 		require => File['/etc/glusterfs/glusterd.vol'],
@@ -131,8 +131,8 @@ class gluster::server(
 		recurse => true,		# recursively manage directory
 		purge => true,
 		force => true,
-		owner => $::gluster::params::conf_owner,
-		group => $::gluster::params::conf_group,
+		owner => "${::gluster::params::misc_owner_conf}",
+		group => "${::gluster::params::misc_group_conf}",
 		mode => 644,
 		notify => Service["${::gluster::params::service_glusterd}"],
 		require => File['/var/lib/glusterd/'],

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -53,8 +53,8 @@ class gluster::server(
 	# this is meant to be replace the excellent sponge utility by sponge.py
 	file { "${vardir}/sponge.py":		# for scripts needing: 'sponge'
 		source => 'puppet:///modules/gluster/sponge.py',
-		owner => root,
-		group => nobody,
+		owner => $::gluster::params::data_owner,
+		group => $::gluster::params::data_group,
 		mode => 700,			# u=rwx
 		backup => false,		# don't backup to filebucket
 		ensure => present,
@@ -89,8 +89,8 @@ class gluster::server(
 		recurse => false,		# TODO: eventually...
 		purge => false,			# TODO: eventually...
 		force => false,			# TODO: eventually...
-		owner => root,
-		group => root,
+		owner => $::gluster::params::conf_owner,
+		group => $::gluster::params::conf_group,
 		mode => 644,
 		#notify => Service["${::gluster::params::service_glusterd}"],	# TODO: ???
 		require => Package["${::gluster::params::package_glusterfs_server}"],
@@ -107,8 +107,8 @@ class gluster::server(
 
 	file { '/etc/glusterfs/glusterd.vol':
 		content => template('gluster/glusterd.vol.erb'),
-		owner => root,
-		group => root,
+		owner => $::gluster::params::conf_owner,
+		group => $::gluster::params::conf_group,
 		mode => 644,			# u=rw,go=r
 		ensure => present,
 		require => File['/etc/glusterfs/'],
@@ -119,8 +119,8 @@ class gluster::server(
 		recurse => false,		# TODO: eventually...
 		purge => false,			# TODO: eventually...
 		force => false,			# TODO: eventually...
-		owner => root,
-		group => root,
+		owner => $::gluster::params::conf_owner,
+		group => $::gluster::params::conf_group,
 		mode => 644,
 		#notify => Service["${::gluster::params::service_glusterd}"],	# TODO: eventually...
 		require => File['/etc/glusterfs/glusterd.vol'],
@@ -131,8 +131,8 @@ class gluster::server(
 		recurse => true,		# recursively manage directory
 		purge => true,
 		force => true,
-		owner => root,
-		group => root,
+		owner => $::gluster::params::conf_owner,
+		group => $::gluster::params::conf_group,
 		mode => 644,
 		notify => Service["${::gluster::params::service_glusterd}"],
 		require => File['/var/lib/glusterd/'],

--- a/manifests/vardir.pp
+++ b/manifests/vardir.pp
@@ -30,8 +30,8 @@ class gluster::vardir {	# module vardir snippet
 			recurse => false,	# don't recurse into directory
 			purge => true,		# purge all unmanaged files
 			force => true,		# also purge subdirs and links
-			owner => $::gluster::params::data_owner,
-			group => $::gluster::params::data_group,
+			owner => "${::gluster::params::misc_owner_data}",
+			group => "${::gluster::params::misc_group_data}",
 			mode => 600,
 			backup => false,	# don't backup to filebucket
 			#before => File["${module_vardir}"],	# redundant
@@ -46,9 +46,9 @@ class gluster::vardir {	# module vardir snippet
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => $::gluster::params::data_owner,
-		group => $::gluster::params::data_group,
-		mode => 600, 
+		owner => "${::gluster::params::misc_owner_data}",
+		group => "${::gluster::params::misc_group_data}",
+		mode => 600,
 		backup => false,
 		require => File["${tmp}"],	# File['/var/lib/puppet/tmp/']
 	}

--- a/manifests/vardir.pp
+++ b/manifests/vardir.pp
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 class gluster::vardir {	# module vardir snippet
+	include gluster::params
+
 	if "${::puppet_vardirtmp}" == '' {
 		if "${::puppet_vardir}" == '' {
 			# here, we require that the puppetlabs fact exist!
@@ -28,8 +30,8 @@ class gluster::vardir {	# module vardir snippet
 			recurse => false,	# don't recurse into directory
 			purge => true,		# purge all unmanaged files
 			force => true,		# also purge subdirs and links
-			owner => root,
-			group => nobody,
+			owner => $::gluster::params::data_owner,
+			group => $::gluster::params::data_group,
 			mode => 600,
 			backup => false,	# don't backup to filebucket
 			#before => File["${module_vardir}"],	# redundant
@@ -44,7 +46,10 @@ class gluster::vardir {	# module vardir snippet
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => $::gluster::params::data_owner,
+		group => $::gluster::params::data_group,
+		mode => 600, 
+		backup => false,
 		require => File["${tmp}"],	# File['/var/lib/puppet/tmp/']
 	}
 }

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -254,8 +254,8 @@ define gluster::volume(
 	# instead, so that we don't inadvertently force some other bad thing...
 	file { "${vardir}/volume/create-${name}.sh":
 		content => inline_template("#!/bin/bash\n/bin/sleep 5s && ${::gluster::params::program_gluster} volume create ${name} ${valid_replica}${valid_stripe}transport ${valid_transport} ${brick_spec} force > >(/usr/bin/tee '/tmp/gluster-volume-create-${name}.stdout') 2> >(/usr/bin/tee '/tmp/gluster-volume-create-${name}.stderr' >&2) || (${rmdir_volume_dirs} && /bin/false)\nexit \$?\n"),
-		owner => $::gluster::params::conf_owner,
-		group => $::gluster::params::conf_group,
+		owner => "${::gluster::params::misc_owner_conf}",
+		group => "${::gluster::params::misc_group_conf}",
 		mode => 755,
 		ensure => present,
 		# this notify is the first to kick off the 2nd step! it

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -319,11 +319,10 @@ define gluster::volume(
 		} elsif ( $start == false ) {
 			# try to stop volume if running
 			# NOTE: this will still succeed even if a client is mounted
-			# NOTE: This uses `yes` to workaround the: Stopping volume will
+			# NOTE: This uses `--mode-script` to workaround the: Stopping volume will
 			# make its data inaccessible. Do you want to continue? (y/n)
-			# TODO: http://community.gluster.org/q/how-can-i-make-automatic-scripts/
-			# TODO: gluster --mode=script volume stop ...
-			exec { "/usr/bin/yes | ${::gluster::params::program_gluster} volume stop ${name}":
+			# https://access.redhat.com/documentation/en-US/Red_Hat_Storage/2.0/html/Installation_Guide/ch08.html
+			exec { "${::gluster::params::program_gluster} --mode=script volume stop ${name}":
 				logoutput => on_failure,
 				onlyif => "${::gluster::params::program_gluster} volume status ${name}",	# returns true if started
 				require => $settled ? {	# require if type exists

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -254,8 +254,8 @@ define gluster::volume(
 	# instead, so that we don't inadvertently force some other bad thing...
 	file { "${vardir}/volume/create-${name}.sh":
 		content => inline_template("#!/bin/bash\n/bin/sleep 5s && ${::gluster::params::program_gluster} volume create ${name} ${valid_replica}${valid_stripe}transport ${valid_transport} ${brick_spec} force > >(/usr/bin/tee '/tmp/gluster-volume-create-${name}.stdout') 2> >(/usr/bin/tee '/tmp/gluster-volume-create-${name}.stderr' >&2) || (${rmdir_volume_dirs} && /bin/false)\nexit \$?\n"),
-		owner => root,
-		group => root,
+		owner => $::gluster::params::conf_owner,
+		group => $::gluster::params::conf_group,
 		mode => 755,
 		ensure => present,
 		# this notify is the first to kick off the 2nd step! it

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -311,7 +311,7 @@ define gluster::volume(
 					},
 				},
 				require => $settled ? {	# require if type exists
-					false => undef,
+					false => Service["${::gluster::params::service_glusterd}"],
 					default => Exec["gluster-volume-create-${name}"],
 				},
 				alias => "gluster-volume-start-${name}",

--- a/manifests/volume/property/group/data.pp
+++ b/manifests/volume/property/group/data.pp
@@ -33,8 +33,8 @@ class gluster::volume::property::group::data() {
 		recurse => true,
 		purge => true,
 		force => true,
-		owner => $::gluster::params::data_owner,
-		group => $::gluster::params::data_group,
+		owner => "${::gluster::params::misc_owner_data}",
+		group => "${::gluster::params::misc_group_data}",
 		mode => 644,			# u=rwx
 		backup => false,		# don't backup to filebucket
 		require => File["${vardir}/"],

--- a/manifests/volume/property/group/data.pp
+++ b/manifests/volume/property/group/data.pp
@@ -22,6 +22,7 @@
 class gluster::volume::property::group::data() {
 
 	include gluster::vardir
+	include gluster::params
 
 	#$vardir = $::gluster::vardir::module_vardir	# with trailing slash
 	$vardir = regsubst($::gluster::vardir::module_vardir, '\/$', '')
@@ -32,8 +33,8 @@ class gluster::volume::property::group::data() {
 		recurse => true,
 		purge => true,
 		force => true,
-		owner => root,
-		group => nobody,
+		owner => $::gluster::params::data_owner,
+		group => $::gluster::params::data_group,
 		mode => 644,			# u=rwx
 		backup => false,		# don't backup to filebucket
 		require => File["${vardir}/"],

--- a/manifests/xml.pp
+++ b/manifests/xml.pp
@@ -38,8 +38,8 @@ class gluster::xml {
 
 	file { "${vardir}/xml.py":
 		source => 'puppet:///modules/gluster/xml.py',
-		owner => root,
-		group => nobody,
+		owner => $::gluster::params::data_owner,
+		group => $::gluster::params::data_group,
 		mode => 700,			# u=rwx
 		backup => false,		# don't backup to filebucket
 		ensure => present,

--- a/manifests/xml.pp
+++ b/manifests/xml.pp
@@ -38,8 +38,8 @@ class gluster::xml {
 
 	file { "${vardir}/xml.py":
 		source => 'puppet:///modules/gluster/xml.py',
-		owner => $::gluster::params::data_owner,
-		group => $::gluster::params::data_group,
+		owner => "${::gluster::params::misc_owner_data}",
+		group => "${::gluster::params::misc_group_data}",
 		mode => 700,			# u=rwx
 		backup => false,		# don't backup to filebucket
 		ensure => present,


### PR DESCRIPTION
I've done small changes to make that module even better (if it's possible...) :
- Added default hieradatas for debian osfamily
- Allowed to use 'glusterfs' or 'ntfs' as fstype for mount (depending of your gluster use, performances could be very impacted by this choice)
- Used `--mode-script` to workaround the: Stopping volume will make its data inaccessible. Do you want to continue? (y/n)
- Corrected race condition : "volume start" cans only be done after installation of glusterfs-server
- Managed awk path in gluster::param
- Added default log directory in order to avoid error message on ubuntu 14.04 with gluster v3.5.2
- Let owner and group be specified because group "nobody" doesn't exist on Ubuntu system.
- Removed obsolete comments