### PR TITLE
Improved 'volume start' conditions

### DIFF
--- a/manifests/volume/property/data.pp
+++ b/manifests/volume/property/data.pp
@@ -292,6 +292,9 @@ class gluster::volume::property::data() {
 		# Number of pages that will be pre-fetched
 		'performance.read-ahead-page-count' => 'integer',	# default: 4
 
+		# enable/disable readdir-ahead translator in the volume.
+		'performance.readdir-ahead' => 'onoff',	# default: off
+
 		# enable/disable meta-data caching translator in the volume.
 		'performance.stat-prefetch' => 'onoff',	# default: on
 

--- a/manifests/volume/property/data.pp
+++ b/manifests/volume/property/data.pp
@@ -293,7 +293,7 @@ class gluster::volume::property::data() {
 		'performance.read-ahead-page-count' => 'integer',	# default: 4
 
 		# enable/disable readdir-ahead translator in the volume.
-		'performance.readdir-ahead' => 'onoff',	# default: off
+		'performance.readdir-ahead' => 'offon',	# default: off
 
 		# enable/disable meta-data caching translator in the volume.
 		'performance.stat-prefetch' => 'onoff',	# default: on

--- a/manifests/volume/property/data.pp
+++ b/manifests/volume/property/data.pp
@@ -104,7 +104,7 @@ class gluster::volume::property::data() {
 		# Sets the quorum percentage for the trusted storage pool.
 		'cluster.server-quorum-ratio' => 'integer',	# in % default: (null)
 
-		# If set to server, enables the specified volume to participate in quorum.
+		# If set to server, enables the specified volume to participate in quorum.
 		'cluster.server-quorum-type' => 'string',	# default: (null)
 
 		# Size of the stripe unit that would be read from or written to the striped servers.


### PR DESCRIPTION
* "Onlyif" and "unless" commands can only run when service_glusterd is
available.
* "Start volume" cans only be used if peer are connected, see $status
and $onlyif of gluster-volume-create exec.