### PR TITLE
Add nobootwait mount options for bricks by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ notifications:
     on_success: always
     on_failure: always
     use_notice: false
-    skip_join: true
+    skip_join: false
   email:
     - travis-ci@shubin.ca
 # TODO: do a full rake test once warnings are all gone!

--- a/data/params/Debian.yaml
+++ b/data/params/Debian.yaml
@@ -14,4 +14,8 @@ gluster::params::program_fping: '/usr/bin/fping'
 gluster::params::program_awk: '/usr/bin/awk'
 # TODO: the debian family of glusterd needs a reload command in the init file !
 gluster::params::misc_gluster_reload: '/usr/sbin/service glusterfs-server restart'
+
+
+gluster::params::mount_nofail: 'nobootwait'
+
 # vim: ts=8

--- a/data/params/RedHat.yaml
+++ b/data/params/RedHat.yaml
@@ -3,6 +3,3 @@
 gluster::params::misc_gluster_repo: 'https://download.gluster.org/pub/gluster/glusterfs/'
 
 # vim: ts=8
-
-# FS Mount params (nobootwait for ubuntu/debian based, override for redhat based OS)
-gluster::params::mount_nobootwait: 'nofail'

--- a/data/params/RedHat.yaml
+++ b/data/params/RedHat.yaml
@@ -3,3 +3,6 @@
 gluster::params::misc_gluster_repo: 'https://download.gluster.org/pub/gluster/glusterfs/'
 
 # vim: ts=8
+
+# FS Mount params (nobootwait for ubuntu/debian based, override for redhat based OS)
+gluster::params::mount_nobootwait: 'nofail'

--- a/manifests/brick.pp
+++ b/manifests/brick.pp
@@ -340,7 +340,7 @@ define gluster::brick(
 			default => '',
 		}
 
-		$options_list = ["${option01}", "${option02}"]
+		$options_list = ["${option01}", "${option02}","${::gluster::params::mount_nofail}"]
 
 	} elsif ( $valid_fstype == 'ext4' ) {
 		# exec requires
@@ -351,7 +351,7 @@ define gluster::brick(
 		$mkfs_exec = "${::gluster::params::program_mkfs_ext4} -U '${valid_fsuuid}' ${dev2}"
 
 		# mount options
-		$options_list = []	# TODO
+		$options_list = ["${::gluster::params::mount_nofail}"]	# TODO
 
 	} elsif ( $valid_fstype == 'btrfs' ) {
 		# exec requires
@@ -364,7 +364,7 @@ define gluster::brick(
 		$mkfs_exec = "${::gluster::params::program_mkfs_btrfs} -U '${valid_fsuuid}' ${dev2}"
 
 		# mount options
-		$options_list = []	# TODO
+		$options_list = ["${::gluster::params::mount_nofail}"]	# TODO
 
 	} else {
 		fail('The $fstype is invalid.')
@@ -374,10 +374,8 @@ define gluster::brick(
 	# commas (this removes ',,' double comma uglyness)
 	# adding 'defaults' here ensures no ',' (leading comma) in mount command
 	
-	## prepend w/ comma
-	$nobootwait = [",${::gluster::params::mount_nobootwait}"]
-
-	$mount_options = inline_template('<%= (["defaults"]+@options_list).delete_if {|x| x.empty? }.join(",") %><%= (@nobootwait).delete_if {|x| x.empty? }.join(",") %>')
+	
+	$mount_options = inline_template('<%= (["defaults"]+@options_list).delete_if {|x| x.empty? }.join(",") %>')
 
 	$exec_noop = $areyousure ? {
 		true => false,

--- a/manifests/brick.pp
+++ b/manifests/brick.pp
@@ -373,7 +373,11 @@ define gluster::brick(
 	# put all the options in an array, remove the empty ones, and join with
 	# commas (this removes ',,' double comma uglyness)
 	# adding 'defaults' here ensures no ',' (leading comma) in mount command
-	$mount_options = inline_template('<%= (["defaults"]+@options_list).delete_if {|x| x.empty? }.join(",") %>')
+	
+	## prepend w/ comma
+	$nobootwait = [",${::gluster::params::mount_nobootwait}"]
+
+	$mount_options = inline_template('<%= (["defaults"]+@options_list).delete_if {|x| x.empty? }.join(",") %><%= (@nobootwait).delete_if {|x| x.empty? }.join(",") %>')
 
 	$exec_noop = $areyousure ? {
 		true => false,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -79,6 +79,9 @@ class gluster::params(
 	# the operatingsystemrelease string used in the repository URL.
 	$misc_repo_operatingsystemrelease = "${operatingsystemrelease}",
 
+	# mount parameter to handle missing FS
+	$mount_nobootwait = 'nobootwait',
+
 	# comment...
 	$comment = ''
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -80,7 +80,7 @@ class gluster::params(
 	$misc_repo_operatingsystemrelease = "${operatingsystemrelease}",
 
 	# mount parameter to handle missing FS
-	$mount_nobootwait = 'nobootwait',
+	$mount_nofail = 'nofail',
 
 	# comment...
 	$comment = ''


### PR DESCRIPTION
AWS-optimized fix -- Add nobootwait by default to a given mount. This pull request is to help ensure that the system can properly boot despite a failed EBS-backed brick. This is probably a best practice to allow for maintenance activity on a failed brick to occur once SSH has been fully loaded, etc.

Let me know if there is a need for a documentaiton update.

Thanks