### PR TITLE
Add nofail and nobootwait for respective OSes

### DIFF
--- a/data/params/Debian.yaml
+++ b/data/params/Debian.yaml
@@ -14,4 +14,8 @@ gluster::params::program_fping: '/usr/bin/fping'
 gluster::params::program_awk: '/usr/bin/awk'
 # TODO: the debian family of glusterd needs a reload command in the init file !
 gluster::params::misc_gluster_reload: '/usr/sbin/service glusterfs-server restart'
+
+# Debian based OS use nobootwait whereas Fedora based OS use nofail.
+gluster::params::misc_mount_nofail: 'nobootwait'
+
 # vim: ts=8

--- a/manifests/brick.pp
+++ b/manifests/brick.pp
@@ -340,7 +340,7 @@ define gluster::brick(
 			default => '',
 		}
 
-		$options_list = ["${option01}", "${option02}"]
+		$options_list = ["${option01}", "${option02}","${::gluster::params::misc_mount_nofail}"]
 
 	} elsif ( $valid_fstype == 'ext4' ) {
 		# exec requires
@@ -351,7 +351,7 @@ define gluster::brick(
 		$mkfs_exec = "${::gluster::params::program_mkfs_ext4} -U '${valid_fsuuid}' ${dev2}"
 
 		# mount options
-		$options_list = []	# TODO
+		$options_list = ["${::gluster::params::misc_mount_nofail}"]	# TODO
 
 	} elsif ( $valid_fstype == 'btrfs' ) {
 		# exec requires
@@ -364,7 +364,7 @@ define gluster::brick(
 		$mkfs_exec = "${::gluster::params::program_mkfs_btrfs} -U '${valid_fsuuid}' ${dev2}"
 
 		# mount options
-		$options_list = []	# TODO
+		$options_list = ["${::gluster::params::misc_mount_nofail}"]	# TODO
 
 	} else {
 		fail('The $fstype is invalid.')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -79,6 +79,9 @@ class gluster::params(
 	# the operatingsystemrelease string used in the repository URL.
 	$misc_repo_operatingsystemrelease = "${operatingsystemrelease}",
 
+	# A failed or missing /etc/fstab entry should not cause the system to hang.
+	$misc_mount_nofail = 'nofail',
+
 	# comment...
 	$comment = ''
 


### PR DESCRIPTION
The purpose of this PR is to allow failed fstab entries to not cause an
OS to hang on boot. This is particularly problematic on cloud providers
like AWS where there is not a quick way to manage an instance and select
a skip option prior to SSH access becoming available.