### PR TITLE
Fix a deprecation warning with stdlib 4.6.0

### DIFF
--- a/manifests/simple.pp
+++ b/manifests/simple.pp
@@ -61,9 +61,18 @@ class gluster::simple(
 
 	$valid_path = sprintf("%s/", regsubst($chosen_path, '\/$', ''))
 
-	$valid_volumes = type($volume) ? {	# always an array of volumes...
-		'array' => $volume,
-		default => ["${volume}"],
+	# Stdlib 4.6.0 deprecates 'type' in favor of 'type3x'. Use if present.
+	# Ensure $valid_volumes is always an array.
+	if is_function_available('type3x') {
+		$valid_volumes = type3x($volume) ? {
+			'array' => $volume,
+			default => ["${volume}"],
+		}
+	} else {
+		$valid_volumes = type($volume) ? {
+			'array' => $volume,
+			default => ["${volume}"],
+		}
 	}
 
 	# if this is a hash, then it's used as the defaults for all the bricks!


### PR DESCRIPTION
[StdLib](https://github.com/puppetlabs/puppetlabs-stdlib) 4.6.0 officially [deprecates the `type` function](https://github.com/puppetlabs/puppetlabs-stdlib/commit/7c8ae311cade65e84df1054779a039ff906e630c), as it is a reserved word for Puppet 4.0, and replaces it with a new `type3x` function. This PR inserts a conditional to test for the existence of a 'type3x' function and uses that. Otherwise, it will use the 'type' function.

This change maintains the listed compatibility with stdlib versions greater than 4.0.0.

This does not create 'future' parser or Puppet 4.0 compatibility.