### PR TITLE
Transition away from deprected 'type' function.

### DIFF
--- a/manifests/brick.pp
+++ b/manifests/brick.pp
@@ -113,7 +113,7 @@ define gluster::brick(
 	}
 
 	# you might see this on first run if the fsuuid isn't generated yet
-	if (type($dev) != 'boolean') and ("${valid_fsuuid}" == '') {
+	if (type3x($dev) != 'boolean') and ("${valid_fsuuid}" == '') {
 		warning('An $fsuuid must be specified or generated.')
 	}
 
@@ -124,7 +124,7 @@ define gluster::brick(
 	# TODO: maybe we can detect these altogether from the raid set!
 	if "${raid_su}" == '' and "${raid_sw}" == '' {
 		# if we are not using a real device, we should ignore warnings!
-		if type($dev) != 'boolean' {			# real devices!
+		if type3x($dev) != 'boolean' {			# real devices!
 			if $lvm or "${fstype}" == 'xfs' {
 				warning('Setting $raid_su and $raid_sw is recommended.')
 			}
@@ -239,7 +239,7 @@ define gluster::brick(
 	}
 
 	# if $dev is false, we assume we're using a path backing store on brick
-	$valid_fstype = type($dev) ? {
+	$valid_fstype = type3x($dev) ? {
 		'boolean' => $dev ? {
 			false => 'path',	# no dev, just a path spec
 			default => '',		# invalid type
@@ -381,7 +381,7 @@ define gluster::brick(
 	}
 
 	# if we're on itself, and we have a real device to work with
-	if (type($dev) != 'boolean') and ("${fqdn}" == "${host}") {
+	if (type3x($dev) != 'boolean') and ("${fqdn}" == "${host}") {
 
 		# partitioning...
 		if $partition {
@@ -521,7 +521,7 @@ define gluster::brick(
 			}
 		}
 
-	} elsif ((type($dev) == 'boolean') and (! $dev)) and ("${fqdn}" == "${host}") {
+	} elsif ((type3x($dev) == 'boolean') and (! $dev)) and ("${fqdn}" == "${host}") {
 
 		# ensure the full path exists!
 		# TODO: is the mkdir needed ?

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -308,7 +308,7 @@ define gluster::host(
 
 		#$other_host_ips = inline_template("<%= ips.delete_if {|x| x == '${ipaddress}' }.join(',') %>")		# list of ips except myself
 		#$all_ips = inline_template("<%= (ips+[vip]+clients).uniq.delete_if {|x| x.empty? }.join(',') %>")
-		$source_ips = type($ips) ? {
+		$source_ips = type3x($ips) ? {
 			'array' => inline_template("<%= (ips+[]).uniq.delete_if {|x| x.empty? }.join(',') %>"),
 			default => ["${valid_ip}"],
 		}

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -147,7 +147,7 @@ class gluster::server(
 
 	if $shorewall {
 		# XXX: WIP
-		#if type($ips) == 'array' {
+		#if type3x($ips) == 'array' {
 		#	#$other_host_ips = inline_template("<%= ips.delete_if {|x| x == '${ipaddress}' }.join(',') %>")		# list of ips except myself
 		#	$source_ips = inline_template("<%= (ips+clients).uniq.delete_if {|x| x.empty? }.join(',') %>")
 		#	#$all_ips = inline_template("<%= (ips+[vip]+clients).uniq.delete_if {|x| x.empty? }.join(',') %>")

--- a/manifests/simple.pp
+++ b/manifests/simple.pp
@@ -61,18 +61,11 @@ class gluster::simple(
 
 	$valid_path = sprintf("%s/", regsubst($chosen_path, '\/$', ''))
 
-	# Stdlib 4.6.0 deprecates 'type' in favor of 'type3x'. Use if present.
+	# Stdlib 4.6.0 deprecates 'type' in favor of 'type3x'.
 	# Ensure $valid_volumes is always an array.
-	if is_function_available('type3x') {
-		$valid_volumes = type3x($volume) ? {
-			'array' => $volume,
-			default => ["${volume}"],
-		}
-	} else {
-		$valid_volumes = type($volume) ? {
-			'array' => $volume,
-			default => ["${volume}"],
-		}
+	$valid_volumes = type3x($volume) ? {
+		'array' => $volume,
+		default => ["${volume}"],
 	}
 
 	# if this is a hash, then it's used as the defaults for all the bricks!

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -51,7 +51,7 @@ define gluster::volume(
 	if $maxlength < $settle_count {
 		fail('The $maxlength needs to be greater than or equal to the $settle_count.')
 	}
-	$are_bricks_collected = (type($bricks) == 'boolean' and ($bricks == true))
+	$are_bricks_collected = (type3x($bricks) == 'boolean' and ($bricks == true))
 	# NOTE: settle checks are still useful even if we are using ping checks
 	# the reason why they are still useful, is that they can detect changes
 	# in the bricks, which might propagate slowly because of exported types
@@ -89,7 +89,7 @@ define gluster::volume(
 		default => brick_layout_simple($replica, $collected_bricks),
 	}
 
-	$valid_bricks = type($bricks) ? {
+	$valid_bricks = type3x($bricks) ? {
 		'boolean' => $bricks ? {
 			true => $ordered_brick_layout,		# an array...
 			default => [],				# invalid type
@@ -341,7 +341,7 @@ define gluster::volume(
 
 		$ips = $::gluster::server::ips		# override host ip list
 		$ip = $::gluster::host::data::ip	# ip of brick's host...
-		$source_ips = type($ips) ? {
+		$source_ips = type3x($ips) ? {
 			'array' => inline_template("<%= (@ips+[]).uniq.delete_if {|x| x.empty? }.join(',') %>"),
 			default => ["${ip}"],
 		}

--- a/manifests/volume/property.pp
+++ b/manifests/volume/property.pp
@@ -72,20 +72,20 @@ define gluster::volume::property(
 	}
 
 	if (! $autotype) {
-		if type($value) != 'string' {
-			fail('Expecting type(string) if autotype is disabled.')
+		if type3x($value) != 'string' {
+			fail('Expecting type3x(string) if autotype is disabled.')
 		}
 		$safe_value = shellquote($value)	# TODO: is this the safe thing?
 
 	# if it's a special offon type and of an acceptable value
 	} elsif ($etype == 'offon') {	# default is off
-		if type($value) == 'boolean' {
+		if type3x($value) == 'boolean' {
 			$safe_value = $value ? {
 				true => 'on',
 				default => 'off',
 			}
 
-		} elsif type($value) == 'string' {
+		} elsif type3x($value) == 'string' {
 			$downcase_value = inline_template('<%= @value.downcase %>')
 			$safe_value = $downcase_value ? {
 				'on' => 'on',
@@ -99,13 +99,13 @@ define gluster::volume::property(
 
 	# if it's a special onoff type and of an acceptable value
 	} elsif ($etype == 'onoff') {	# default is on
-		if type($value) == 'boolean' {
+		if type3x($value) == 'boolean' {
 			$safe_value = $value ? {
 				false => 'off',
 				default => 'on',
 			}
 
-		} elsif type($value) == 'string' {
+		} elsif type3x($value) == 'string' {
 			$downcase_value = inline_template('<%= @value.downcase %>')
 			$safe_value = $downcase_value ? {
 				'off' => 'off',
@@ -119,13 +119,13 @@ define gluster::volume::property(
 
 	# if it's a special truefalse type and of an acceptable value
 	} elsif ($etype == 'truefalse') {	# default is true
-		if type($value) == 'boolean' {
+		if type3x($value) == 'boolean' {
 			$safe_value = $value ? {
 				false => 'false',
 				default => 'true',
 			}
 
-		} elsif type($value) == 'string' {
+		} elsif type3x($value) == 'string' {
 			$downcase_value = inline_template('<%= @value.downcase %>')
 			$safe_value = $downcase_value ? {
 				'false' => 'false',
@@ -138,13 +138,13 @@ define gluster::volume::property(
 
 	# if it's a special falsetrue type and of an acceptable value
 	} elsif ($etype == 'falsetrue') {	# default is false
-		if type($value) == 'boolean' {
+		if type3x($value) == 'boolean' {
 			$safe_value = $value ? {
 				true => 'true',
 				default => 'false',
 			}
 
-		} elsif type($value) == 'string' {
+		} elsif type3x($value) == 'string' {
 			$downcase_value = inline_template('<%= @value.downcase %>')
 			$safe_value = $downcase_value ? {
 				'true' => 'true',
@@ -166,7 +166,7 @@ define gluster::volume::property(
 		$safe_value = shellquote($value)	# TODO: is this the safe thing?
 
 	# if it's not a string and it's not the expected type, fail
-	} elsif ( type($value) != $etype ) {	# type() from puppetlabs-stdlib
+	} elsif ( type3x($value) != $etype ) {	# type3x() from puppetlabs-stdlib
 		fail("Gluster::Volume::Property[${key}] must be type: ${etype}.")
 
 	# convert to correct type

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
 	"name": "purpleidea-gluster",
-	"version": "0.0.5",
+	"version": "0.1.0",
 	"author": "James Shubin",
 	"summary": "A Puppet module for GlusterFS",
 	"license": "GNU Affero General Public License, Version 3.0+",
@@ -9,7 +9,7 @@
 	"issues_url": null,
 	"description": "UNKNOWN",
 	"dependencies": [
-		{ "name": "puppetlabs/stdlib", "version_requirement": ">= 4.0.0" }
+		{ "name": "puppetlabs/stdlib", "version_requirement": ">= 4.6.0" }
 	]
 }
 


### PR DESCRIPTION
This transitions away from the deprecated `type` function in stdlib and moves to `type3x`. This requires updating the dependencies from *at least stdlib 4.0.0* to *at least stdlib 4.6.0*, so metadata.json is updated, and the semantic version bumped as this version will break if used with the previous dependencies.