### PR TITLE
Fix interface fact name for vrrp

### DIFF
--- a/lib/facter/gluster_vrrp.rb
+++ b/lib/facter/gluster_vrrp.rb
@@ -172,7 +172,7 @@ if not(ipfile.nil?) and File.exist?(ipfile)
 			end
 
 			# lookup from fact
-			netmask = Facter.value('netmask_'+interface)
+			netmask = Facter.value('netmask_'+interface.gsub('-','_'))
 			if netmaskregexp.match(netmask)
 
 				Facter.add('gluster_vrrp_netmask') do


### PR DESCRIPTION
When using bridges, the interface names are usually in the form br-*,
but the dashes are replaced by underscores in facter.
This patch corrects the vrrp facter module to allow support for
interfaces with such names.