### PR TITLE
Don't set any keepalived master on first run

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -278,7 +278,7 @@ define gluster::host(
 
 			keepalived::vrrp { 'VI_GLUSTER':	# TODO: groups!
 				state => "${fqdns[0]}" ? {	# first in list
-					'' => 'MASTER',		# list is empty
+					'' => 'BACKUP',		# list is empty
 					"${fqdn}" => 'MASTER',	# we are first!
 					default => 'BACKUP',	# other in list
 				},


### PR DESCRIPTION
During the first run, the fact gluster_vrrp_fqdns is empty, leading to
all nodes to be set as keepalived master. This could cause race
conditions on the second run when gluster volumes are created because
every node has the VIP, and it is an invalid state anyway.
