### PR TITLE
Make fact gluster_host suppress the error output, if Resolv.getaddres…

### DIFF
--- a/lib/facter/gluster_host.rb
+++ b/lib/facter/gluster_host.rb
@@ -21,7 +21,7 @@ require 'resolv'
 # try and pick the _right_ ip that gluster should use by default...
 fqdn = Facter.value('fqdn')
 if not fqdn.nil?
-	ip = Resolv.getaddress "#{fqdn}"
+	ip = Resolv.getaddress "#{fqdn}" || ''
 	if not ip.nil?
 		Facter.add('gluster_host_ip') do
 			#confine :operatingsystem => %w{CentOS, RedHat, Fedora}


### PR DESCRIPTION
…s does not work at all, e.g. DNS setup not complete during provisioning stage of a VM.