### PR TITLE
fuse glusterfs mount doesn't support remount option

### DIFF
--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -182,6 +182,10 @@ define gluster::mount(
 	# XXX: or something... consider adding the notify => Poke[] functionality
 	mount { "${short_name}":
 		atboot => true,
+		remounts => "${valid_type}" ? {
+			'glusterfs' => false,
+			default => true,
+		},
 		ensure => $mounted_bool,
 		device => "${server}",
 		fstype => "${valid_type}",


### PR DESCRIPTION
Since 3.6, it now throws an error like:

```
Info: Mount[/mnt/](provider=parsed): Remounting
Error: /Stage[main]/Gluster::Mount[/mnt/]/Mount[/mnt/]: Failed to call refresh: Execution of '/bin/mount /mnt/' returned 1: Invalid option remount
```

By hand same thing as [mount.glusterfs](https://github.com/gluster/glusterfs/blob/release-3.6/xlators/mount/fuse/utils/mount.glusterfs.in#L467) is rejecting it.

This commit disable `remounts` if fstype is glusterfs. This is not ideal (see [puppet mount](https://docs.puppetlabs.com/references/latest/type.html#mount-attribute-remounts)) but should fix the puppet run in most cases.